### PR TITLE
Improve Event Registry polling and add setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,99 @@
 # x-bot
+
+Automation tools for sharing the latest Bitcoin mining news on Twitter.
+
+## Features
+
+- Polls the [Event Registry](https://eventregistry.org/) minute stream for
+  recent Bitcoin mining activity using the ``GetRecentArticles`` API.
+- Persists the latest ``updatesAfterNewsUri``, ``updatesAfterBlogUri`` and
+  ``updatesAfterPrUri`` checkpoints so that repeated runs only fetch new
+  content.
+- Posts concise summaries for unseen articles to Twitter via the Tweepy
+  client.
+
+## Prerequisites
+
+1. Python 3.10+.
+2. Valid Event Registry API key with access to the minute stream.
+3. A Twitter/X developer application with read and write permissions.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+The bot is configured entirely through environment variables. In the Codex
+environment, define the required secrets via the **Secrets** pane and allow the
+runner to inject them into your commands. The provided `scripts/setup.sh`
+helper script validates that the secrets are available and can be used to run
+commands with the injected credentials.
+
+```bash
+# Check credentials and run the bot in dry-run mode
+./scripts/setup.sh python -m bot.main --dry-run
+```
+
+Set the following values before running the script:
+
+| Variable | Description |
+| --- | --- |
+| `EVENT_REGISTRY_API_KEY` | API key used to authenticate with Event Registry. |
+| `TWITTER_BEARER_TOKEN` | Optional bearer token for Tweepy (used for rate limit handling). |
+| `TWITTER_API_KEY` | Twitter consumer key. |
+| `TWITTER_API_SECRET` | Twitter consumer secret. |
+| `TWITTER_ACCESS_TOKEN` | Twitter access token with write permissions. |
+| `TWITTER_ACCESS_SECRET` | Twitter access token secret. |
+
+Optional environment variables provide additional control:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `BOT_QUERY` | `bitcoin mining` | Keyword used to detect relevant articles. |
+| `BOT_STATE_PATH` | `bot/state.json` | File path used to persist API checkpoints and posted article URIs. |
+| `BOT_ARTICLE_LANG` | *(unset)* | Restrict Event Registry results to a specific ISO language code. |
+| `BOT_POLL_INTERVAL` | `300` | Delay (in seconds) between polls when running with `--loop`. |
+| `BOT_LOG_LEVEL` | `INFO` | Logging verbosity. |
+
+The state file stores the last known `updatesAfterNewsUri`,
+`updatesAfterBlogUri`, `updatesAfterPrUri`, and a short history of article
+URIs that have already been posted to Twitter. Deleting this file resets the
+checkpoints.
+
+## Usage
+
+After configuring the environment variables, run the bot directly or via the
+setup helper:
+
+```bash
+# Direct invocation (environment variables already exported)
+python -m bot.main
+
+# Or via the Codex-aware helper script
+./scripts/setup.sh python -m bot.main
+```
+
+Key command-line options:
+
+- `--loop`: continuously poll Event Registry at the configured interval.
+- `--dry-run`: fetch and log new articles without posting to Twitter.
+- `--state-file`: override the location of the JSON state file.
+
+Example (continuous polling every 10 minutes):
+
+```bash
+BOT_POLL_INTERVAL=600 python -m bot.main --loop
+```
+
+## Development Notes
+
+- The package entry point lives in `bot/main.py`.
+- Dependencies are listed in `requirements.txt` for convenience, but the
+  project does not enforce a specific virtual environment manager.
+- Tweepy exceptions are logged and skipped so that a failure to post a single
+  tweet does not interrupt the polling loop.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Set the following values before running the script:
 
 | Variable | Description |
 | --- | --- |
-| `EVENT_REGISTRY_API_KEY` | API key used to authenticate with Event Registry. |
+| `EVENT_REGISTRY_API_KEY` | API key used to authenticate with Event Registry. (`NEWSAPI_API_KEY` is accepted as a fallback.) |
 | `TWITTER_BEARER_TOKEN` | Optional bearer token for Tweepy (used for rate limit handling). |
 | `TWITTER_API_KEY` | Twitter consumer key. |
 | `TWITTER_API_SECRET` | Twitter consumer secret. |
 | `TWITTER_ACCESS_TOKEN` | Twitter access token with write permissions. |
-| `TWITTER_ACCESS_SECRET` | Twitter access token secret. |
+| `TWITTER_ACCESS_TOKEN_SECRET` | Twitter access token secret. (`TWITTER_ACCESS_SECRET` is also recognised for compatibility.) |
 
 Optional environment variables provide additional control:
 

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,7 @@
+"""Automation tools for sharing Bitcoin mining news."""
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,483 @@
+"""Command-line entry point for the Bitcoin mining news bot.
+
+The module polls the Event Registry API for recent Bitcoin mining
+articles, stores the latest ``updatesAfterNewsUri``,
+``updatesAfterBlogUri`` and ``updatesAfterPrUri`` checkpoints, and posts
+summaries for newly discovered articles to Twitter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+import tweepy
+from eventregistry import (
+    ArticleInfoFlags,
+    EventRegistry,
+    GetRecentArticles,
+    QueryArticles,
+    ReturnInfo,
+)
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_QUERY = "bitcoin mining"
+MAX_TWEET_LENGTH = 280
+POSTED_HISTORY_LIMIT = 250
+
+UPDATES_AFTER_PARAMS: Mapping[str, str] = {
+    "recentActivityArticlesNewsUpdatesAfterUri": "updatesAfterNewsUri",
+    "recentActivityArticlesBlogsUpdatesAfterUri": "updatesAfterBlogUri",
+    "recentActivityArticlesPrUpdatesAfterUri": "updatesAfterPrUri",
+}
+
+
+class BotConfigurationError(RuntimeError):
+    """Raised when a required configuration value is missing."""
+
+
+def load_state(path: Path) -> Dict[str, Any]:
+    """Load persisted state from ``path``.
+
+    The state dictionary always provides ``updatesAfterNewsUri``,
+    ``updatesAfterBlogUri``, ``updatesAfterPrUri`` and
+    ``postedArticleUris`` keys.
+    """
+
+    if not path.exists():
+        return {
+            "updatesAfterNewsUri": None,
+            "updatesAfterBlogUri": None,
+            "updatesAfterPrUri": None,
+            "postedArticleUris": [],
+        }
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:  # pragma: no cover - defensive
+        raise RuntimeError(f"Failed to load bot state from {path}: {exc}") from exc
+
+    data.setdefault("updatesAfterNewsUri", None)
+    data.setdefault("updatesAfterBlogUri", None)
+    data.setdefault("updatesAfterPrUri", None)
+    data.setdefault("postedArticleUris", [])
+    return data
+
+
+def save_state(path: Path, state: MutableMapping[str, Any]) -> None:
+    """Persist the state dictionary to ``path``."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=2, sort_keys=True)
+
+
+def create_event_registry(api_key: Optional[str]) -> EventRegistry:
+    """Create an :class:`~eventregistry.EventRegistry` client."""
+
+    if not api_key:
+        raise BotConfigurationError(
+            "EVENT_REGISTRY_API_KEY is required to connect to Event Registry."
+        )
+    LOGGER.debug("Initialising EventRegistry client")
+    return EventRegistry(apiKey=api_key)
+
+
+def create_twitter_client() -> tweepy.Client:
+    """Create and configure the Tweepy client."""
+
+    bearer_token = os.getenv("TWITTER_BEARER_TOKEN")
+    api_key = os.getenv("TWITTER_API_KEY")
+    api_secret = os.getenv("TWITTER_API_SECRET")
+    access_token = os.getenv("TWITTER_ACCESS_TOKEN")
+    access_secret = os.getenv("TWITTER_ACCESS_SECRET")
+
+    missing = [
+        name
+        for name, value in [
+            ("TWITTER_API_KEY", api_key),
+            ("TWITTER_API_SECRET", api_secret),
+            ("TWITTER_ACCESS_TOKEN", access_token),
+            ("TWITTER_ACCESS_SECRET", access_secret),
+        ]
+        if not value
+    ]
+    if missing:
+        joined = ", ".join(missing)
+        raise BotConfigurationError(
+            f"Missing Twitter credentials: {joined}. Set the variables before running."
+        )
+
+    LOGGER.debug("Initialising Tweepy client")
+    return tweepy.Client(
+        bearer_token=bearer_token,
+        consumer_key=api_key,
+        consumer_secret=api_secret,
+        access_token=access_token,
+        access_token_secret=access_secret,
+        wait_on_rate_limit=True,
+    )
+
+
+def build_article_return_info() -> ReturnInfo:
+    """Return a :class:`~eventregistry.ReturnInfo` describing article fields."""
+
+    return ReturnInfo(
+        articleInfo=ArticleInfoFlags(
+            bodyLen=400,
+            title=True,
+            body=True,
+            url=True,
+            authors=False,
+            concepts=True,
+            categories=False,
+        )
+    )
+
+
+def build_recent_articles_request(
+    er: EventRegistry,
+    *,
+    query: str,
+    article_lang: Optional[str],
+    state: MutableMapping[str, Any],
+) -> GetRecentArticles:
+    """Prepare a :class:`~eventregistry.GetRecentArticles` request."""
+
+    kwargs: Dict[str, Any] = {}
+    if state.get("updatesAfterNewsUri"):
+        kwargs["recentActivityArticlesNewsUpdatesAfterUri"] = state["updatesAfterNewsUri"]
+    if state.get("updatesAfterBlogUri"):
+        kwargs["recentActivityArticlesBlogsUpdatesAfterUri"] = state["updatesAfterBlogUri"]
+    if state.get("updatesAfterPrUri"):
+        kwargs["recentActivityArticlesPrUpdatesAfterUri"] = state["updatesAfterPrUri"]
+
+    # Restrict results to the configured language when provided.
+    if article_lang:
+        kwargs["articleLang"] = article_lang
+
+    # Event Registry expects filters prefixed with "recentActivityArticles".
+    # This narrows the feed to articles that mention the Bitcoin mining keyword.
+    kwargs["recentActivityArticlesKeyword"] = query
+
+    return GetRecentArticles(
+        er,
+        returnInfo=build_article_return_info(),
+        **kwargs,
+    )
+
+
+def sync_updates_after(
+    query_params: Mapping[str, Any],
+    state: MutableMapping[str, Any],
+) -> None:
+    """Persist ``GetRecentArticles`` pagination checkpoints into ``state``."""
+
+    for param_key, state_key in UPDATES_AFTER_PARAMS.items():
+        value = query_params.get(param_key)
+        if value:
+            state[state_key] = value
+
+
+def enrich_articles(
+    er: EventRegistry,
+    activity: Iterable[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Fetch enriched article details for the provided activity feed."""
+
+    activity_list = list(activity)
+    uris = [item.get("uri") for item in activity_list if item.get("uri")]
+    if not uris:
+        return activity_list
+
+    query = QueryArticles.initWithArticleUriList(
+        uris,
+        returnInfo=build_article_return_info(),
+    )
+    try:
+        response = er.execQuery(query)
+    except Exception as exc:  # pragma: no cover - external API
+        LOGGER.error("Failed to enrich articles: %s", exc)
+        return activity_list
+    if not isinstance(response, dict):
+        LOGGER.warning("Unexpected article enrichment payload from Event Registry")
+        return activity_list
+
+    articles = response.get("articles", {}).get("results", [])
+    if not isinstance(articles, list):
+        LOGGER.warning("Unexpected article results returned during enrichment")
+        return activity_list
+
+    detailed_by_uri = {
+        str(article.get("uri")): article
+        for article in articles
+        if isinstance(article, dict) and article.get("uri")
+    }
+
+    enriched: List[Dict[str, Any]] = []
+    for item in activity_list:
+        uri = item.get("uri")
+        detailed = detailed_by_uri.get(str(uri)) if uri is not None else None
+        if detailed:
+            merged = {**item, **detailed}
+        else:
+            merged = dict(item)
+        enriched.append(merged)
+    return enriched
+
+
+def fetch_recent_activity(
+    er: EventRegistry,
+    *,
+    query: str,
+    article_lang: Optional[str],
+    state: MutableMapping[str, Any],
+) -> List[Dict[str, Any]]:
+    """Fetch the recent activity list and update ``state`` checkpoints."""
+
+    request = build_recent_articles_request(
+        er, query=query, article_lang=article_lang, state=state
+    )
+
+    LOGGER.debug("Requesting recent activity from Event Registry")
+    try:
+        activity = request.getUpdates()
+    except Exception as exc:  # pragma: no cover - external API
+        LOGGER.error("Failed to fetch recent activity: %s", exc)
+        return []
+
+    if not isinstance(activity, list):
+        LOGGER.warning("Unexpected activity payload returned by Event Registry")
+        activity = []
+
+    sync_updates_after(request.queryParams, state)
+
+    if not activity:
+        LOGGER.info("No recent activity returned by Event Registry")
+        return []
+
+    enriched = enrich_articles(er, activity)
+    LOGGER.info("Retrieved %d enriched articles from recent activity", len(enriched))
+    return [
+        article
+        for article in enriched
+        if is_bitcoin_mining_article(article, query=query)
+    ]
+
+
+def is_bitcoin_mining_article(article: Dict[str, Any], *, query: str) -> bool:
+    """Return ``True`` if the article appears to reference Bitcoin mining."""
+
+    query_lower = query.lower()
+    fields = [
+        str(article.get("title", "")),
+        str(article.get("body", "")),
+    ]
+    for field in fields:
+        if query_lower in field.lower():
+            return True
+    for concept in article.get("concepts", []) or []:
+        label = concept.get("label", {}).get("eng") if isinstance(concept, dict) else None
+        if label and query_lower in str(label).lower():
+            return True
+    return False
+
+
+def format_tweet(article: Dict[str, Any]) -> str:
+    """Build a tweet summarising the provided article."""
+
+    title = (article.get("title") or "Untitled article").strip()
+    summary = article.get("body") or ""
+    url = article.get("url") or article.get("permalink") or ""
+
+    summary = " ".join(summary.split())
+    if summary:
+        summary = summary[:160].rstrip()
+    text = title
+    if summary:
+        text = f"{title} — {summary}"
+
+    if url:
+        candidate = f"{text} {url}".strip()
+    else:
+        candidate = text
+
+    if len(candidate) <= MAX_TWEET_LENGTH:
+        return candidate
+
+    ellipsis = "…"
+    available = MAX_TWEET_LENGTH - len(url) - 1 if url else MAX_TWEET_LENGTH
+    truncated = text[: max(0, available - 1)].rstrip()
+    truncated = truncated[:-1] + ellipsis if truncated.endswith(".") else truncated + ellipsis
+
+    if url:
+        return f"{truncated} {url}".strip()
+    return truncated
+
+
+def post_articles(
+    twitter_client: tweepy.Client,
+    articles: Iterable[Dict[str, Any]],
+    *,
+    state: MutableMapping[str, Any],
+    dry_run: bool,
+) -> None:
+    """Post unseen articles to Twitter and update state."""
+
+    posted_uris: List[str] = list(state.get("postedArticleUris", []))
+    for article in articles:
+        uri = article.get("uri")
+        if not uri:
+            LOGGER.debug("Skipping article without URI: %s", article)
+            continue
+        if uri in posted_uris:
+            LOGGER.debug("Skipping already-posted article %s", uri)
+            continue
+
+        tweet = format_tweet(article)
+        if dry_run:
+            LOGGER.info("[DRY RUN] Would post tweet: %s", tweet)
+        else:
+            LOGGER.info("Posting tweet for article %s", uri)
+            try:
+                twitter_client.create_tweet(text=tweet)
+            except tweepy.TweepyException as exc:  # pragma: no cover - external API
+                LOGGER.error("Failed to post tweet for %s: %s", uri, exc)
+                continue
+
+        posted_uris.append(uri)
+        if len(posted_uris) > POSTED_HISTORY_LIMIT:
+            posted_uris = posted_uris[-POSTED_HISTORY_LIMIT:]
+
+    state["postedArticleUris"] = posted_uris
+
+
+def configure_logging(level: str) -> None:
+    """Configure the root logger."""
+
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--query",
+        default=os.getenv("BOT_QUERY", DEFAULT_QUERY),
+        help="Keyword used to filter Bitcoin mining news (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--state-file",
+        default=os.getenv(
+            "BOT_STATE_PATH", Path(__file__).resolve().parent / "state.json"
+        ),
+        help="Location of the JSON file used to persist API checkpoints",
+    )
+    parser.add_argument(
+        "--article-lang",
+        default=os.getenv("BOT_ARTICLE_LANG"),
+        help="Restrict Event Registry results to the provided language code",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=int(os.getenv("BOT_POLL_INTERVAL", "300")),
+        help="Delay in seconds when running in --loop mode (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--loop",
+        action="store_true",
+        help="Continuously poll Event Registry at the configured interval",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch data but do not post updates to Twitter",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=os.getenv("BOT_LOG_LEVEL", "INFO"),
+        help="Logging verbosity (default: %(default)s)",
+    )
+    return parser.parse_args(argv)
+
+
+def run_once(
+    *,
+    er: EventRegistry,
+    twitter_client: tweepy.Client,
+    query: str,
+    article_lang: Optional[str],
+    state: MutableMapping[str, Any],
+    dry_run: bool,
+) -> None:
+    """Execute a single poll/post cycle."""
+
+    try:
+        articles = fetch_recent_activity(
+            er, query=query, article_lang=article_lang, state=state
+        )
+    except Exception as exc:  # pragma: no cover - external API
+        LOGGER.error("Failed to fetch recent activity: %s", exc)
+        return
+
+    if not articles:
+        LOGGER.info("No Bitcoin mining updates found in this cycle")
+        return
+
+    post_articles(twitter_client, articles, state=state, dry_run=dry_run)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point used by ``python -m bot.main``."""
+
+    args = parse_args(argv)
+    configure_logging(args.log_level)
+
+    state_path = Path(args.state_file).expanduser().resolve()
+    state = load_state(state_path)
+
+    try:
+        er = create_event_registry(os.getenv("EVENT_REGISTRY_API_KEY"))
+        twitter_client = create_twitter_client()
+    except BotConfigurationError as exc:
+        LOGGER.error(str(exc))
+        return 2
+
+    LOGGER.info("Starting Bitcoin mining news poller")
+    LOGGER.debug("Using state file at %s", state_path)
+
+    try:
+        while True:
+            run_once(
+                er=er,
+                twitter_client=twitter_client,
+                query=args.query,
+                article_lang=args.article_lang,
+                state=state,
+                dry_run=args.dry_run,
+            )
+            save_state(state_path, state)
+            if not args.loop:
+                break
+            LOGGER.debug("Sleeping for %s seconds", args.poll_interval)
+            time.sleep(max(1, args.poll_interval))
+    except KeyboardInterrupt:
+        LOGGER.info("Interrupted by user; exiting.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+eventregistry>=9.1
+tweepy>=4.16.0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,26 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REQUIRED_SECRETS=(
-  EVENT_REGISTRY_API_KEY
-  TWITTER_API_KEY
-  TWITTER_API_SECRET
-  TWITTER_ACCESS_TOKEN
-  TWITTER_ACCESS_SECRET
-)
+ensure_secret() {
+  local primary="$1"
+  shift
+  local value="${!primary:-}"
+  if [[ -n "$value" ]]; then
+    printf '  - %s length: %s\n' "$primary" "${#value}"
+    return 0
+  fi
+
+  local alt alt_value
+  for alt in "$@"; do
+    alt_value="${!alt:-}"
+    if [[ -n "$alt_value" ]]; then
+      printf '  - %s not set, using %s (length: %s)\n' \
+        "$primary" "$alt" "${#alt_value}"
+      export "$primary"="$alt_value"
+      return 0
+    fi
+  done
+
+  printf '  - %s is missing.\n' "$primary" >&2
+  return 1
+}
 
 missing=0
 printf 'Checking required secrets...\n'
-for var in "${REQUIRED_SECRETS[@]}"; do
-  value="${!var:-}"
-  if [[ -z "$value" ]]; then
-    printf '  - %s is missing.\n' "$var" >&2
-    missing=1
-  else
-    printf '  - %s length: %s\n' "$var" "${#value}"
-  fi
-  unset value
-done
+
+ensure_secret EVENT_REGISTRY_API_KEY NEWSAPI_API_KEY || missing=1
+ensure_secret TWITTER_API_KEY || missing=1
+ensure_secret TWITTER_API_SECRET || missing=1
+ensure_secret TWITTER_ACCESS_TOKEN || missing=1
+ensure_secret TWITTER_ACCESS_TOKEN_SECRET TWITTER_ACCESS_SECRET || missing=1
 
 if (( missing )); then
   printf '\nOne or more required secrets are unavailable. Configure them in the Codex environment and retry.\n' >&2

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REQUIRED_SECRETS=(
+  EVENT_REGISTRY_API_KEY
+  TWITTER_API_KEY
+  TWITTER_API_SECRET
+  TWITTER_ACCESS_TOKEN
+  TWITTER_ACCESS_SECRET
+)
+
+missing=0
+printf 'Checking required secrets...\n'
+for var in "${REQUIRED_SECRETS[@]}"; do
+  value="${!var:-}"
+  if [[ -z "$value" ]]; then
+    printf '  - %s is missing.\n' "$var" >&2
+    missing=1
+  else
+    printf '  - %s length: %s\n' "$var" "${#value}"
+  fi
+  unset value
+done
+
+if (( missing )); then
+  printf '\nOne or more required secrets are unavailable. Configure them in the Codex environment and retry.\n' >&2
+  exit 1
+fi
+
+if (( $# )); then
+  printf '\nExecuting command with injected secrets:'
+  for arg in "$@"; do
+    printf ' %q' "$arg"
+  done
+  printf '\n\n'
+  exec "$@"
+fi
+
+printf '\nAll required secrets are available.\n'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,137 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from bot import main
+
+
+class FakeEventRegistry:
+    def __init__(self, response):
+        self.response = response
+        self.requests = []
+
+    def execQuery(self, query):  # pragma: no cover - simple pass-through
+        self.requests.append(query)
+        return self.response
+
+
+class FakeTwitterClient:
+    def __init__(self):
+        self.tweets = []
+
+    def create_tweet(self, text):  # pragma: no cover - simple pass-through
+        self.tweets.append(text)
+
+
+class MainModuleTests(unittest.TestCase):
+    def test_sync_updates_after_writes_all_known_keys(self):
+        state = {
+            "updatesAfterNewsUri": None,
+            "updatesAfterBlogUri": None,
+            "updatesAfterPrUri": None,
+        }
+        params = {
+            "recentActivityArticlesNewsUpdatesAfterUri": "news-uri",
+            "recentActivityArticlesBlogsUpdatesAfterUri": "blog-uri",
+            "recentActivityArticlesPrUpdatesAfterUri": "pr-uri",
+        }
+
+        main.sync_updates_after(params, state)
+
+        self.assertEqual(state["updatesAfterNewsUri"], "news-uri")
+        self.assertEqual(state["updatesAfterBlogUri"], "blog-uri")
+        self.assertEqual(state["updatesAfterPrUri"], "pr-uri")
+
+    def test_format_tweet_truncates_summary(self):
+        article = {
+            "title": "Bitcoin Mining Breakthrough",
+            "body": " ".join(["A" * 80] * 5),
+            "url": "https://example.com/article",
+        }
+
+        tweet = main.format_tweet(article)
+
+        self.assertLessEqual(len(tweet), main.MAX_TWEET_LENGTH)
+        self.assertIn("https://example.com/article", tweet)
+
+    def test_enrich_articles_merges_detailed_results(self):
+        response = {
+            "articles": {
+                "results": [
+                    {
+                        "uri": "uri-1",
+                        "title": "Detailed",
+                        "body": "Fresh context",
+                    }
+                ]
+            }
+        }
+        er = FakeEventRegistry(response)
+        enriched = main.enrich_articles(er, [{"uri": "uri-1", "title": "Original"}])
+
+        self.assertEqual(len(enriched), 1)
+        self.assertEqual(enriched[0]["title"], "Detailed")
+        self.assertEqual(enriched[0]["body"], "Fresh context")
+
+    def test_enrich_articles_falls_back_on_unexpected_payload(self):
+        er = FakeEventRegistry(None)
+        activity = [{"uri": "uri-1", "title": "Original"}]
+
+        enriched = main.enrich_articles(er, activity)
+
+        self.assertEqual(enriched, activity)
+
+    def test_post_articles_skips_duplicates_and_tracks_new_entries(self):
+        client = FakeTwitterClient()
+        state = {"postedArticleUris": ["uri-1"]}
+        articles = [
+            {"uri": "uri-1", "title": "Duplicate", "body": "Already posted"},
+            {
+                "uri": "uri-2",
+                "title": "Brand new Mining Report",
+                "body": "Details about Bitcoin mining advancements",
+                "url": "https://example.com/report",
+            },
+        ]
+
+        main.post_articles(client, articles, state=state, dry_run=False)
+
+        self.assertEqual(len(client.tweets), 1)
+        self.assertIn("uri-2", state["postedArticleUris"])
+        self.assertNotIn("uri-1", client.tweets[0])  # ensure we only posted new URI
+
+    def test_is_bitcoin_mining_article_detects_keyword(self):
+        article = {"title": "Global Bitcoin mining trends", "body": ""}
+
+        self.assertTrue(main.is_bitcoin_mining_article(article, query="bitcoin mining"))
+        self.assertFalse(
+            main.is_bitcoin_mining_article({"title": "Random", "body": "Irrelevant"}, query="bitcoin mining")
+        )
+
+    def test_state_round_trip(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = Path(tempdir) / "state.json"
+            state = main.load_state(path)
+            self.assertEqual(
+                state,
+                {
+                    "updatesAfterNewsUri": None,
+                    "updatesAfterBlogUri": None,
+                    "updatesAfterPrUri": None,
+                    "postedArticleUris": [],
+                },
+            )
+
+            state["updatesAfterNewsUri"] = "news"
+            main.save_state(path, state)
+
+            with path.open("r", encoding="utf-8") as handle:
+                saved = json.load(handle)
+
+            self.assertEqual(saved["updatesAfterNewsUri"], "news")
+            self.assertIn("postedArticleUris", saved)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve Event Registry polling by reusing GetRecentArticles pagination data, enriching activity payloads, and mapping checkpoint updates into the persisted state
- add a Codex-aware setup helper script and document how to run the bot with injected secrets
- create unit tests for state persistence, tweet formatting, enrichment, and posting behaviour

## Testing
- python -m compileall bot
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68c9acaf9ebc8329b5f4d209879a65fc