### PR TITLE
Add Bitcoin mining Event Registry bot and tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,27 @@ pip install -r requirements.txt
 
 ## Configuration
 
-The bot is configured entirely through environment variables. Set the
-following values before running the script:
+The bot is configured entirely through environment variables. In the Codex
+environment, define the required secrets via the **Secrets** pane and allow the
+runner to inject them into your commands. The provided `scripts/setup.sh`
+helper script validates that the secrets are available and can be used to run
+commands with the injected credentials.
+
+```bash
+# Check credentials and run the bot in dry-run mode
+./scripts/setup.sh python -m bot.main --dry-run
+```
+
+Set the following values before running the script:
 
 | Variable | Description |
 | --- | --- |
-| `EVENT_REGISTRY_API_KEY` | API key used to authenticate with Event Registry. |
+| `EVENT_REGISTRY_API_KEY` | API key used to authenticate with Event Registry. (`NEWSAPI_API_KEY` is accepted as a fallback.) |
 | `TWITTER_BEARER_TOKEN` | Optional bearer token for Tweepy (used for rate limit handling). |
 | `TWITTER_API_KEY` | Twitter consumer key. |
 | `TWITTER_API_SECRET` | Twitter consumer secret. |
 | `TWITTER_ACCESS_TOKEN` | Twitter access token with write permissions. |
-| `TWITTER_ACCESS_SECRET` | Twitter access token secret. |
+| `TWITTER_ACCESS_TOKEN_SECRET` | Twitter access token secret. (`TWITTER_ACCESS_SECRET` is also recognised for compatibility.) |
 
 Optional environment variables provide additional control:
 
@@ -57,10 +67,15 @@ checkpoints.
 
 ## Usage
 
-After configuring the environment variables, run the bot:
+After configuring the environment variables, run the bot directly or via the
+setup helper:
 
 ```bash
+# Direct invocation (environment variables already exported)
 python -m bot.main
+
+# Or via the Codex-aware helper script
+./scripts/setup.sh python -m bot.main
 ```
 
 Key command-line options:

--- a/bot/main.py
+++ b/bot/main.py
@@ -15,13 +15,14 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, MutableMapping, Optional
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
 
 import tweepy
 from eventregistry import (
     ArticleInfoFlags,
     EventRegistry,
     GetRecentArticles,
+    QueryArticles,
     ReturnInfo,
 )
 
@@ -29,6 +30,12 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_QUERY = "bitcoin mining"
 MAX_TWEET_LENGTH = 280
 POSTED_HISTORY_LIMIT = 250
+
+UPDATES_AFTER_PARAMS: Mapping[str, str] = {
+    "recentActivityArticlesNewsUpdatesAfterUri": "updatesAfterNewsUri",
+    "recentActivityArticlesBlogsUpdatesAfterUri": "updatesAfterBlogUri",
+    "recentActivityArticlesPrUpdatesAfterUri": "updatesAfterPrUri",
+}
 
 
 class BotConfigurationError(RuntimeError):
@@ -72,7 +79,24 @@ def save_state(path: Path, state: MutableMapping[str, Any]) -> None:
         json.dump(state, handle, indent=2, sort_keys=True)
 
 
-def create_event_registry(api_key: Optional[str]) -> EventRegistry:
+def resolve_event_registry_api_key() -> str:
+    """Return the Event Registry API key from known environment variables."""
+
+    for env_name in ("EVENT_REGISTRY_API_KEY", "NEWSAPI_API_KEY"):
+        api_key = os.getenv(env_name)
+        if api_key:
+            if env_name != "EVENT_REGISTRY_API_KEY":
+                LOGGER.debug(
+                    "Using %s as the Event Registry credential source", env_name
+                )
+            return api_key
+    raise BotConfigurationError(
+        "EVENT_REGISTRY_API_KEY is required to connect to Event Registry. "
+        "Provide the key via EVENT_REGISTRY_API_KEY or NEWSAPI_API_KEY."
+    )
+
+
+def create_event_registry(api_key: str) -> EventRegistry:
     """Create an :class:`~eventregistry.EventRegistry` client."""
 
     if not api_key:
@@ -90,7 +114,16 @@ def create_twitter_client() -> tweepy.Client:
     api_key = os.getenv("TWITTER_API_KEY")
     api_secret = os.getenv("TWITTER_API_SECRET")
     access_token = os.getenv("TWITTER_ACCESS_TOKEN")
-    access_secret = os.getenv("TWITTER_ACCESS_SECRET")
+    access_secret = os.getenv("TWITTER_ACCESS_TOKEN_SECRET")
+    secret_env_name = "TWITTER_ACCESS_TOKEN_SECRET"
+    if not access_secret:
+        legacy_secret = os.getenv("TWITTER_ACCESS_SECRET")
+        if legacy_secret:
+            LOGGER.debug(
+                "Using TWITTER_ACCESS_SECRET as fallback for TWITTER_ACCESS_TOKEN_SECRET"
+            )
+            access_secret = legacy_secret
+            secret_env_name = "TWITTER_ACCESS_SECRET"
 
     missing = [
         name
@@ -98,7 +131,7 @@ def create_twitter_client() -> tweepy.Client:
             ("TWITTER_API_KEY", api_key),
             ("TWITTER_API_SECRET", api_secret),
             ("TWITTER_ACCESS_TOKEN", access_token),
-            ("TWITTER_ACCESS_SECRET", access_secret),
+            (secret_env_name, access_secret),
         ]
         if not value
     ]
@@ -119,16 +152,10 @@ def create_twitter_client() -> tweepy.Client:
     )
 
 
-def build_recent_articles_request(
-    er: EventRegistry,
-    *,
-    query: str,
-    article_lang: Optional[str],
-    state: MutableMapping[str, Any],
-) -> GetRecentArticles:
-    """Prepare a :class:`~eventregistry.GetRecentArticles` request."""
+def build_article_return_info() -> ReturnInfo:
+    """Return a :class:`~eventregistry.ReturnInfo` describing article fields."""
 
-    return_info = ReturnInfo(
+    return ReturnInfo(
         articleInfo=ArticleInfoFlags(
             bodyLen=400,
             title=True,
@@ -139,6 +166,16 @@ def build_recent_articles_request(
             categories=False,
         )
     )
+
+
+def build_recent_articles_request(
+    er: EventRegistry,
+    *,
+    query: str,
+    article_lang: Optional[str],
+    state: MutableMapping[str, Any],
+) -> GetRecentArticles:
+    """Prepare a :class:`~eventregistry.GetRecentArticles` request."""
 
     kwargs: Dict[str, Any] = {}
     if state.get("updatesAfterNewsUri"):
@@ -156,7 +193,70 @@ def build_recent_articles_request(
     # This narrows the feed to articles that mention the Bitcoin mining keyword.
     kwargs["recentActivityArticlesKeyword"] = query
 
-    return GetRecentArticles(er, returnInfo=return_info, **kwargs)
+    return GetRecentArticles(
+        er,
+        returnInfo=build_article_return_info(),
+        **kwargs,
+    )
+
+
+def sync_updates_after(
+    query_params: Mapping[str, Any],
+    state: MutableMapping[str, Any],
+) -> None:
+    """Persist ``GetRecentArticles`` pagination checkpoints into ``state``."""
+
+    for param_key, state_key in UPDATES_AFTER_PARAMS.items():
+        value = query_params.get(param_key)
+        if value:
+            state[state_key] = value
+
+
+def enrich_articles(
+    er: EventRegistry,
+    activity: Iterable[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Fetch enriched article details for the provided activity feed."""
+
+    activity_list = list(activity)
+    uris = [item.get("uri") for item in activity_list if item.get("uri")]
+    if not uris:
+        return activity_list
+
+    query = QueryArticles.initWithArticleUriList(
+        uris,
+        returnInfo=build_article_return_info(),
+    )
+    try:
+        response = er.execQuery(query)
+    except Exception as exc:  # pragma: no cover - external API
+        LOGGER.error("Failed to enrich articles: %s", exc)
+        return activity_list
+    if not isinstance(response, dict):
+        LOGGER.warning("Unexpected article enrichment payload from Event Registry")
+        return activity_list
+
+    articles = response.get("articles", {}).get("results", [])
+    if not isinstance(articles, list):
+        LOGGER.warning("Unexpected article results returned during enrichment")
+        return activity_list
+
+    detailed_by_uri = {
+        str(article.get("uri")): article
+        for article in articles
+        if isinstance(article, dict) and article.get("uri")
+    }
+
+    enriched: List[Dict[str, Any]] = []
+    for item in activity_list:
+        uri = item.get("uri")
+        detailed = detailed_by_uri.get(str(uri)) if uri is not None else None
+        if detailed:
+            merged = {**item, **detailed}
+        else:
+            merged = dict(item)
+        enriched.append(merged)
+    return enriched
 
 
 def fetch_recent_activity(
@@ -173,31 +273,27 @@ def fetch_recent_activity(
     )
 
     LOGGER.debug("Requesting recent activity from Event Registry")
-    response = er.execQuery(request)
-    recent = response.get("recentActivityArticles", {}) if isinstance(response, dict) else {}
-    newest_uri = recent.get("newestUri", {})
-
-    if newest_uri:
-        news_uri = newest_uri.get("news")
-        blog_uri = newest_uri.get("blogs") or newest_uri.get("blog")
-        pr_uri = newest_uri.get("pr")
-
-        if news_uri:
-            state["updatesAfterNewsUri"] = news_uri
-        if blog_uri:
-            state["updatesAfterBlogUri"] = blog_uri
-        if pr_uri:
-            state["updatesAfterPrUri"] = pr_uri
-
-    activity = recent.get("activity", [])
-    if not isinstance(activity, list):
-        LOGGER.warning("Unexpected activity payload returned by Event Registry")
+    try:
+        activity = request.getUpdates()
+    except Exception as exc:  # pragma: no cover - external API
+        LOGGER.error("Failed to fetch recent activity: %s", exc)
         return []
 
-    LOGGER.info("Retrieved %d articles from recent activity", len(activity))
+    if not isinstance(activity, list):
+        LOGGER.warning("Unexpected activity payload returned by Event Registry")
+        activity = []
+
+    sync_updates_after(request.queryParams, state)
+
+    if not activity:
+        LOGGER.info("No recent activity returned by Event Registry")
+        return []
+
+    enriched = enrich_articles(er, activity)
+    LOGGER.info("Retrieved %d enriched articles from recent activity", len(enriched))
     return [
         article
-        for article in activity
+        for article in enriched
         if is_bitcoin_mining_article(article, query=query)
     ]
 
@@ -379,7 +475,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     state = load_state(state_path)
 
     try:
-        er = create_event_registry(os.getenv("EVENT_REGISTRY_API_KEY"))
+        er = create_event_registry(resolve_event_registry_api_key())
         twitter_client = create_twitter_client()
     except BotConfigurationError as exc:
         LOGGER.error(str(exc))

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ensure_secret() {
+  local primary="$1"
+  shift
+  local value="${!primary:-}"
+  if [[ -n "$value" ]]; then
+    printf '  - %s length: %s\n' "$primary" "${#value}"
+    return 0
+  fi
+
+  local alt alt_value
+  for alt in "$@"; do
+    alt_value="${!alt:-}"
+    if [[ -n "$alt_value" ]]; then
+      printf '  - %s not set, using %s (length: %s)\n' \
+        "$primary" "$alt" "${#alt_value}"
+      export "$primary"="$alt_value"
+      return 0
+    fi
+  done
+
+  printf '  - %s is missing.\n' "$primary" >&2
+  return 1
+}
+
+missing=0
+printf 'Checking required secrets...\n'
+
+ensure_secret EVENT_REGISTRY_API_KEY NEWSAPI_API_KEY || missing=1
+ensure_secret TWITTER_API_KEY || missing=1
+ensure_secret TWITTER_API_SECRET || missing=1
+ensure_secret TWITTER_ACCESS_TOKEN || missing=1
+ensure_secret TWITTER_ACCESS_TOKEN_SECRET TWITTER_ACCESS_SECRET || missing=1
+
+if (( missing )); then
+  printf '\nOne or more required secrets are unavailable. Configure them in the Codex environment and retry.\n' >&2
+  exit 1
+fi
+
+if (( $# )); then
+  printf '\nExecuting command with injected secrets:'
+  for arg in "$@"; do
+    printf ' %q' "$arg"
+  done
+  printf '\n\n'
+  exec "$@"
+fi
+
+printf '\nAll required secrets are available.\n'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,137 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from bot import main
+
+
+class FakeEventRegistry:
+    def __init__(self, response):
+        self.response = response
+        self.requests = []
+
+    def execQuery(self, query):  # pragma: no cover - simple pass-through
+        self.requests.append(query)
+        return self.response
+
+
+class FakeTwitterClient:
+    def __init__(self):
+        self.tweets = []
+
+    def create_tweet(self, text):  # pragma: no cover - simple pass-through
+        self.tweets.append(text)
+
+
+class MainModuleTests(unittest.TestCase):
+    def test_sync_updates_after_writes_all_known_keys(self):
+        state = {
+            "updatesAfterNewsUri": None,
+            "updatesAfterBlogUri": None,
+            "updatesAfterPrUri": None,
+        }
+        params = {
+            "recentActivityArticlesNewsUpdatesAfterUri": "news-uri",
+            "recentActivityArticlesBlogsUpdatesAfterUri": "blog-uri",
+            "recentActivityArticlesPrUpdatesAfterUri": "pr-uri",
+        }
+
+        main.sync_updates_after(params, state)
+
+        self.assertEqual(state["updatesAfterNewsUri"], "news-uri")
+        self.assertEqual(state["updatesAfterBlogUri"], "blog-uri")
+        self.assertEqual(state["updatesAfterPrUri"], "pr-uri")
+
+    def test_format_tweet_truncates_summary(self):
+        article = {
+            "title": "Bitcoin Mining Breakthrough",
+            "body": " ".join(["A" * 80] * 5),
+            "url": "https://example.com/article",
+        }
+
+        tweet = main.format_tweet(article)
+
+        self.assertLessEqual(len(tweet), main.MAX_TWEET_LENGTH)
+        self.assertIn("https://example.com/article", tweet)
+
+    def test_enrich_articles_merges_detailed_results(self):
+        response = {
+            "articles": {
+                "results": [
+                    {
+                        "uri": "uri-1",
+                        "title": "Detailed",
+                        "body": "Fresh context",
+                    }
+                ]
+            }
+        }
+        er = FakeEventRegistry(response)
+        enriched = main.enrich_articles(er, [{"uri": "uri-1", "title": "Original"}])
+
+        self.assertEqual(len(enriched), 1)
+        self.assertEqual(enriched[0]["title"], "Detailed")
+        self.assertEqual(enriched[0]["body"], "Fresh context")
+
+    def test_enrich_articles_falls_back_on_unexpected_payload(self):
+        er = FakeEventRegistry(None)
+        activity = [{"uri": "uri-1", "title": "Original"}]
+
+        enriched = main.enrich_articles(er, activity)
+
+        self.assertEqual(enriched, activity)
+
+    def test_post_articles_skips_duplicates_and_tracks_new_entries(self):
+        client = FakeTwitterClient()
+        state = {"postedArticleUris": ["uri-1"]}
+        articles = [
+            {"uri": "uri-1", "title": "Duplicate", "body": "Already posted"},
+            {
+                "uri": "uri-2",
+                "title": "Brand new Mining Report",
+                "body": "Details about Bitcoin mining advancements",
+                "url": "https://example.com/report",
+            },
+        ]
+
+        main.post_articles(client, articles, state=state, dry_run=False)
+
+        self.assertEqual(len(client.tweets), 1)
+        self.assertIn("uri-2", state["postedArticleUris"])
+        self.assertNotIn("uri-1", client.tweets[0])  # ensure we only posted new URI
+
+    def test_is_bitcoin_mining_article_detects_keyword(self):
+        article = {"title": "Global Bitcoin mining trends", "body": ""}
+
+        self.assertTrue(main.is_bitcoin_mining_article(article, query="bitcoin mining"))
+        self.assertFalse(
+            main.is_bitcoin_mining_article({"title": "Random", "body": "Irrelevant"}, query="bitcoin mining")
+        )
+
+    def test_state_round_trip(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = Path(tempdir) / "state.json"
+            state = main.load_state(path)
+            self.assertEqual(
+                state,
+                {
+                    "updatesAfterNewsUri": None,
+                    "updatesAfterBlogUri": None,
+                    "updatesAfterPrUri": None,
+                    "postedArticleUris": [],
+                },
+            )
+
+            state["updatesAfterNewsUri"] = "news"
+            main.save_state(path, state)
+
+            with path.open("r", encoding="utf-8") as handle:
+                saved = json.load(handle)
+
+            self.assertEqual(saved["updatesAfterNewsUri"], "news")
+            self.assertIn("postedArticleUris", saved)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand the README with configuration details and helper usage for secrets
- implement the Event Registry polling entry point with state tracking and Tweet posting
- add a setup script plus unit tests covering enrichment, filtering, and state persistence

## Testing
- python -m pytest tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b90b7cf483298194db0c7a461a5a