### PR TITLE
Allow dry-run without Twitter credentials

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Test configuration for pytest."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- allow the Twitter client setup to be skipped when running in dry-run mode so that missing credentials no longer abort the bot
- tighten posting safeguards and extend the test suite to cover the new behaviour
- configure pytest to locate the project package when invoked via the `pytest` entry point

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cae9ba0c188329908faa97b4a27933